### PR TITLE
docs: add Artifact Hub badges and links

### DIFF
--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -12,6 +12,8 @@ Integrations → Add Cluster → Enter name → Generate credentials → Downloa
 
 ## 2. Install the Operator
 
+The Helm chart is available on [Artifact Hub](https://artifacthub.io/packages/helm/obsyk-operator/obsyk-operator).
+
 ```bash
 # Add the Obsyk Helm repository
 helm repo add obsyk https://obsyk.github.io/obsyk-operator

--- a/docs/operator/installation.md
+++ b/docs/operator/installation.md
@@ -1,6 +1,8 @@
 # Operator Installation
 
-Deploy the Obsyk operator to your Kubernetes cluster.
+[![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/obsyk-operator)](https://artifacthub.io/packages/helm/obsyk-operator/obsyk-operator)
+
+Deploy the Obsyk operator to your Kubernetes cluster. The Helm chart is available on [Artifact Hub](https://artifacthub.io/packages/helm/obsyk-operator/obsyk-operator).
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary

Add Artifact Hub references to installation documentation.

## Changes

- Add Artifact Hub badge to operator installation page
- Add Artifact Hub link to quickstart guide

🤖 Generated with [Claude Code](https://claude.com/claude-code)